### PR TITLE
Add time display to visualizer

### DIFF
--- a/src/RigidBodySim.jl
+++ b/src/RigidBodySim.jl
@@ -32,6 +32,7 @@ using DrakeVisualizer
 
 using RigidBodyDynamics: configuration_derivative! # TODO: export from RigidBodyDynamics
 
+include("lcmtypes/utime_t.jl")
 include("periodic.jl")
 include("control.jl")
 include("core.jl")

--- a/src/lcmtypes/utime_t.jl
+++ b/src/lcmtypes/utime_t.jl
@@ -1,0 +1,12 @@
+# TODO: move somewhere else
+using LCMCore
+using StaticArrays
+
+mutable struct UTimeT <: LCMType
+    utime::Int64
+end
+
+LCMCore.fingerprint(::Type{UTimeT}) = SVector(0x4d, 0x0d, 0x41, 0xc1, 0xf1, 0x05, 0xb1, 0x2f)
+LCMCore.size_fields(::Type{UTimeT}) = ()
+Base.resize!(::UTimeT) = nothing
+LCMCore.check_valid(::UTimeT) = nothing

--- a/src/rigid_body_sim_visualizer_script.py
+++ b/src/rigid_body_sim_visualizer_script.py
@@ -2,8 +2,11 @@ import json
 from director import lcmUtils
 from director.utime import getUtime
 import robotlocomotion as lcmrl
+import bot_core as lcmbotcore
+import inspect
 
-channel = 'RIGID_BODY_SIM_CONTROL'
+controlChannel = 'RIGID_BODY_SIM_CONTROL'
+timeChannel = 'RIGID_BODY_SIM_TIME'
 
 def sendControlMessage(contents):
     msg = lcmrl.viewer2_comms_t()
@@ -14,10 +17,31 @@ def sendControlMessage(contents):
     data = dict(**contents)
     msg.data = bytearray(json.dumps(data), encoding='utf-8')
     msg.num_bytes = len(msg.data)
-    lcmUtils.publish(channel, msg)
+    lcmUtils.publish(controlChannel, msg)
 
 def terminate():
     sendControlMessage({'terminate': None})
 
+class TimeDisplay:
+
+    def __init__(self):
+        self.widget = QtGui.QLabel('')
+        self.widget.setFixedWidth(60)
+        self.widget.setToolTip('Simulation time')
+        self.widget.setAlignment(QtCore.Qt.AlignRight)
+        self.setTime(0)
+        self.subscriber = lcmUtils.addSubscriber(timeChannel, callback=self.onMessage)
+
+    def setTime(self, t):
+        self.widget.setText('{:.2f}'.format(t))
+
+    def onMessage(self, msgBytes, channel):
+        msg = lcmbotcore.utime_t.decode(msgBytes.data())
+        self.setTime(msg.utime / 1000.)
+
+
 toolBar = app.addToolBar("RigidBodySim.jl")
+timeDisplay = TimeDisplay()
+toolBar.addWidget(timeDisplay.widget)
 app.addToolBarAction(toolBar, 'Stop Simulation/Playback', icon=':/images/media/media-playback-stop.png', callback=terminate)
+# timeDisplay.setTime(1)


### PR DESCRIPTION
Fix #22. Also ensure that the state precisely at the end of the integration time interval gets drawn.