### PR TITLE
Don't use Reexport anymore.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,4 +5,3 @@ DiffEqCallbacks 1.0.0
 RigidBodyTreeInspector 0.3.2
 LoopThrottle 0.0.1
 DocStringExtensions 0.4.1
-Reexport 0.1

--- a/notebooks/Quick start guide.ipynb
+++ b/notebooks/Quick start guide.ipynb
@@ -17,18 +17,8 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mRecompiling stale cache file /home/twan/code/RigidBodyDynamics/lib/v0.6/RigidBodySim.ji for module RigidBodySim.\n",
-      "\u001b[39m"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -142,18 +132,15 @@
     }
    ],
    "source": [
-    "using RigidBodySim"
+    "using RigidBodySim\n",
+    "using RigidBodyDynamics"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`RigidBodySim` reexports all symbols from the following packages:\n",
-    "* [`RigidBodyDynamics`](https://github.com/tkoolen/RigidBodyDynamics.jl)\n",
-    "* [`RigidBodyTreeInspector`](https://github.com/rdeits/RigidBodyTreeInspector.jl)\n",
-    "\n",
-    "In addition, it reexports select symbols from packages in the [`DifferentialEquations`](https://github.com/JuliaDiffEq/DifferentialEquations.jl) ecosystem. To access additional `DifferentialEquations` features, simply add one or more of the following:\n",
+    "`RigidBodySim` reexports select symbols from RigidBodyTreeInspector.jl, as well as from packages in the [`DifferentialEquations`](https://github.com/JuliaDiffEq/DifferentialEquations.jl) ecosystem. To access additional `DifferentialEquations` features, simply add one or more of the following:\n",
     "```julia\n",
     "using DiffEqBase # basics\n",
     "using OrdinaryDiffEq # more ODE-related functionality\n",
@@ -179,9 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "urdf = Pkg.dir(\"RigidBodySim\", \"test\", \"urdf\", \"Acrobot.urdf\")\n",
@@ -199,9 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "state = MechanismState(mechanism)\n",
@@ -233,9 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -274,9 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "any_open_visualizer_windows() || (new_visualizer_window(); sleep(1));"
@@ -299,9 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "vis = Visualizer(mechanism, parse_urdf(urdf, mechanism))\n",
@@ -310,9 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "# Simulating while visualizing"
    ]
@@ -329,9 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "vis_callbacks = CallbackSet(vis, state);"
@@ -349,9 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sol = solve(problem, Tsit5(), abs_tol = 1e-10, dt = 0.05, callback = vis_callbacks);"
@@ -390,9 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "problem = ODEProblem(state, (0., 5.))\n",
@@ -402,9 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "animate(vis, state, sol; realtime_rate = 0.5)"
@@ -412,9 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Like with simulation, the 'stop' button in the visualizer window can be used to terminate visualization early."
    ]
@@ -456,9 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -481,9 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "controlproblem = ODEProblem(state, (0., 5.), control!)\n",
@@ -508,9 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "τ = similar(velocity(state))\n",
@@ -528,16 +487,14 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "DiffEqBase.ODEProblem with uType Array{Float64,1} and tType Float64. In-place: true\n",
        "timespan: (0.0, 5.0)\n",
-       "u0: [0.0121495, 0.471529, -1.43205, -0.50953]"
+       "u0: [0.195491, 0.440061, 1.05505, 0.918594]"
       ]
      },
      "execution_count": 14,
@@ -559,9 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sol = solve(periodic_control_problem, Tsit5(), abs_tol = 1e-10, dt = 0.05, callback = vis_callbacks);"
@@ -577,9 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "animate(vis, state, sol)"
@@ -588,9 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -609,5 +560,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/src/RigidBodySim.jl
+++ b/src/RigidBodySim.jl
@@ -3,22 +3,19 @@ __precompile__()
 module RigidBodySim
 
 using Compat
-using Reexport
-
-@reexport using RigidBodyDynamics
-@reexport using RigidBodyTreeInspector
-
+using RigidBodyDynamics
+using RigidBodyTreeInspector
 using OrdinaryDiffEq
 using DiffEqCallbacks
 using LoopThrottle
 using JSON
 using LCMCore
 using DrakeVisualizer
-
-using DataStructures: top
-using RigidBodyDynamics: configuration_derivative! # TODO: export from RigidBodyDynamics
-
 using DocStringExtensions
+
+import DataStructures
+import RigidBodyTreeInspector: animate, Visualizer, settransform!
+
 @template (FUNCTIONS, METHODS, MACROS) =
     """
     $(SIGNATURES)
@@ -41,6 +38,12 @@ export
     Vern7, # from OrdinaryDiffEq
     RK4, # from OrdinaryDiffEq
     CallbackSet # from DiffEqCallbacks
+
+# select RigidBodyTreeInspector exports
+export
+    animate,
+    Visualizer,
+    settransform!
 
 # Control
 export

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -65,7 +65,7 @@ function transform_publisher(state::MechanismState, vis::Visualizer, lcm::LCM; m
     last_update_time = Ref(-Inf)
     condition = let last_update_time = last_update_time, min_Δt = 1 / max_fps
         function (u, t, integrator)
-            last_time_step = length(integrator.opts.tstops) == 1 && t == top(integrator.opts.tstops)
+            last_time_step = length(integrator.opts.tstops) == 1 && t == DataStructures.top(integrator.opts.tstops)
             last_time_step || time() - last_update_time[] >= min_Δt
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 module RigidBodySimTest
 
+using RigidBodyDynamics
 using RigidBodySim
 
 using JSON
@@ -7,6 +8,7 @@ using LCMCore
 
 import DiffEqCallbacks: DiscreteCallback
 import DiffEqBase: add_tstop!
+import RigidBodyTreeInspector: settransform!
 
 using Base.Test
 


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/21653. Note that OrdinaryDiffEq.jl still uses Reexport.jl and my hunch that this is Reexport-related is unconfirmed, but still.
